### PR TITLE
Bugfixes

### DIFF
--- a/source/stop_token.hpp
+++ b/source/stop_token.hpp
@@ -7,7 +7,7 @@
 #include <utility>
 
 #if defined(__x86_64__) || defined(_M_X64)
-#include <xmmintrin.h>
+#include <immintrin.h>
 #endif
 
 namespace std {

--- a/source/test_cv.cpp
+++ b/source/test_cv.cpp
@@ -501,7 +501,7 @@ void testTimedIWait(bool callNotify, bool callInterrupt, Dur dur)
                             std::cout.put(it.stop_requested() ? 'T' : 't').flush();
                           }
                         }
-                        catch (const char* e) {
+                        catch ([[maybe_unused]] const char* e) {
                           //std::cout << "t1: interrupted" << std::endl;
                           std::cout.put('i').flush();
                           t1Feedback = State::interrupted;

--- a/source/test_cvrace_hh.cpp
+++ b/source/test_cvrace_hh.cpp
@@ -50,13 +50,13 @@ using namespace::std::literals;
 //  So, either the test or the fix seems to be wrong.
 //
 // HH:
-//  I’m guessing that to reliably test this, one is going to have to rebuild your condition_variable_any2
+//  Iï¿½m guessing that to reliably test this, one is going to have to rebuild your condition_variable_any2
 //  with an internal mutex that checks for unlock-after-destruction.
 //  And the problem with that is now you no no longer have a std::mutex to put into your internal std::condition_variable...
 //
 //  _Maybe_ you could test it by making your internal std::condition_variable a std::condition_variable_any,
 //  then you could put a debugging mutex into it.
-//  But I’m not sure, because this is getting pretty weird and I have not actually tried this.
+//  But Iï¿½m not sure, because this is getting pretty weird and I have not actually tried this.
 //------------------------------------------------------
 
 #ifndef ORIG_CVANY_RACE_TEST
@@ -69,7 +69,7 @@ void f() {
     m.lock();
     f_ready = true;
     cv->notify_one();
-    delete cv;
+    cv->~condition_variable_any2();
     std::memset(cv, 0x55, sizeof(*cv)); // UB but OK to ensure the check
     m.unlock();
 }
@@ -141,7 +141,7 @@ void testCVAnyMutex()
                     std::unique_lock ul{m};
                     f_ready = true;
                     cv->notify_one();
-                    delete cv;
+                    cv->~condition_variable_any2();
                     std::memset(cv, 0x55, sizeof(*cv)); // UB but OK to ensure the check
                  });
   t1.join();

--- a/source/test_jthread1.cpp
+++ b/source/test_jthread1.cpp
@@ -316,7 +316,7 @@ void testTemporarilyDisableToken()
                        throw "interrupted";
                      }
                    }
-                   catch (const char* e) {
+                   catch ([[maybe_unused]] const char* e) {
                      std::cout.put('i').flush();
                      state.store(State::interrupted); 
                    }

--- a/source/test_jthread2.cpp
+++ b/source/test_jthread2.cpp
@@ -60,7 +60,7 @@ void interruptByDestructor()
                      catch (std::exception&) { // interrupted not derived from std::exception
                        assert(false);
                      }
-                     catch (const char* e) {
+                     catch ([[maybe_unused]] const char* e) {
                        assert(stoken.stop_requested());
                        t1WasInterrupted = true;
                        //throw;


### PR DESCRIPTION
- Fix some compiler warnings about unused variables in tests.
- Fix double-free bug in test_cvrace_hh.cpp
- Use correct header for _mm_pause() function (immintrin.h instead of xmmintrin.h)