### PR TITLE
Add template deduction guides for stop_callback

### DIFF
--- a/source/stop_token.hpp
+++ b/source/stop_token.hpp
@@ -487,4 +487,11 @@ class [[nodiscard]] stop_callback : private __stop_callback_base {
   __stop_state* __state_;
   _Callback __cb_;
 };
+
+template<typename _Callback>
+stop_callback(const stop_token&, _Callback&&) -> stop_callback<_Callback>;
+
+template<typename _Callback>
+stop_callback(stop_token&&, _Callback&&) -> stop_callback<_Callback>;
+
 } // namespace std

--- a/tex/jthread.tex
+++ b/tex/jthread.tex
@@ -112,6 +112,12 @@ namespace std {
     // \expos
     Callback callback; 
   };
+
+  template <typename Callback>
+  stop_callback(const stop_token&, Callback&&) -> stop_callback<Callback>;
+
+  template <typename Callback>
+  stop_callback(stop_token&&, Callback&&) -> stop_callback<Callback>;
 }
 \end{codeblock}
 


### PR DESCRIPTION
This allows constructing a stop_callback with an lvalue callable.
eg.
```c++
auto lambda = []{};
std::stop_callback cb{ token, lambda }; // captures by reference
```