### PR TITLE
Add some more test-cases for stop_token

### DIFF
--- a/source/stop_token.hpp
+++ b/source/stop_token.hpp
@@ -487,4 +487,11 @@ class [[nodiscard]] stop_callback : private __stop_callback_base {
   __stop_state* __state_;
   _Callback __cb_;
 };
+
+template<typename _Callback>
+stop_callback(const stop_token&, _Callback&&) -> stop_callback<_Callback>;
+
+template<typename _Callback>
+stop_callback(stop_token&&, _Callback&&) -> stop_callback<_Callback>;
+
 } // namespace std

--- a/source/test.hpp
+++ b/source/test.hpp
@@ -1,0 +1,113 @@
+#ifndef TEST_HPP
+#define TEST_HPP
+
+#include <iostream>
+#include <cassert>
+#include <atomic>
+
+class test_entry
+{
+    static std::atomic<bool> any_failures;
+    static test_entry* first;
+    static test_entry* last;
+
+    test_entry* next;
+    test_entry* prev;
+    const char* name;
+    void(*testFunc)();
+
+public:
+
+    explicit test_entry(const char* name, void(*testFunc)()) noexcept
+        : next(nullptr)
+        , prev(last)
+        , name(name)
+        , testFunc(testFunc)
+    {
+        if (last != nullptr) {
+            last->next = this;
+        } else {
+            first = this;
+        }
+        last = this;
+    }
+
+    ~test_entry()
+    {
+        if (prev == nullptr) {
+            first = next;
+        } else {
+            prev->next = next;
+        }
+
+        if (next == nullptr) {
+            last = prev;
+        } else {
+            next->prev = prev;
+        }
+    }
+
+    bool run()
+    {
+        any_failures = false;
+        std::cout << "Test " << name << std::endl;
+        try {
+            testFunc();
+        }
+        catch (const std::exception& ex) {
+            assert(false);
+            std::cout << "  FAIL: unhandled exception: " << ex.what() << std::endl;
+            any_failures = true;
+        }
+        catch (...) {
+            assert(false);
+            std::cout << "  FAIL: unhandled exception" << std::endl;
+            any_failures = true;
+        }
+        return !any_failures;
+    }
+
+    static int run_all()
+    {
+        int failureCount = 0;
+        for (auto* entry = first; entry != nullptr; entry = entry->next) {
+            if (!entry->run()) {
+                ++failureCount;
+            }
+        }
+        return failureCount;
+    }
+
+    static void check_failed(const char* msg)
+    {
+        assert(false);
+        std::cout << "  FAIL: " << msg << std::endl;
+        any_failures = true;
+    }
+};
+
+std::atomic<bool> test_entry::any_failures = false;
+test_entry* test_entry::first = nullptr;
+test_entry* test_entry::last = nullptr;
+
+// Macro for auto-registering a test-case to be run when you call test_entry::run_all().
+//
+// Usage:
+//  TEST(SomeTest)
+//  {
+//    CHECK(someCond);
+//  }
+#define TEST(NAME) \
+  static void NAME(); \
+  static ::test_entry test_entry_##NAME{#NAME, &NAME}; \
+  static void NAME()
+
+// Alternative to assert() macro.
+// If parameter evaluates to false then causes current test to be reported as failed.
+// Does not stop the program from continuing.
+#define CHECK(X) \
+    do { \
+        if ((X)) {} else { ::test_entry::check_failed("CHECK(" #X ")"); } \
+    } while (false)
+
+#endif

--- a/tex/jthread.tex
+++ b/tex/jthread.tex
@@ -112,6 +112,12 @@ namespace std {
     // \expos
     Callback callback; 
   };
+
+  template <typename Callback>
+  stop_callback(const stop_token&, Callback&&) -> stop_callback<Callback>;
+
+  template <typename Callback>
+  stop_callback(stop_token&&, Callback&&) -> stop_callback<Callback>;
 }
 \end{codeblock}
 


### PR DESCRIPTION
- Test for deregistering callback from within callback.
- Test that callback destructor blocks until callback finishes
  executing.
- Test that callback destructor does not block on other callbacks
  executing.
- Add simple helper for registering and running tests.

Requires https://github.com/josuttis/jthread/pull/8