### PR TITLE
Fixes for std::condition_variable_any2 wait-functions that take a predicate and no stop_token

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -97,6 +97,15 @@ test_cvrace_stop: stop_token.hpp jthread.hpp condition_variable_any2.hpp test_cv
 run_cvrace_stop: test_cvrace_stop
 	./test_cvrace_stop17raw.exe
 
+test_cvrace_pred: condition_variable_any2.hpp test_cvrace_pred.cpp Makefile
+	$(CXX17) $(CXXFLAGS17) $(INCLUDES) test_cvrace_pred.cpp $(LDFLAGS17) -o $@17raw.exe
+	echo PATH=\"$(PATH17)/bin:$$PATH\" ./$@17raw.exe '$$*' > $@17.exe
+	echo PATH=\"$(PATH17)/bin:$$PATH\" ./$@17raw.exe '$$*' > $@.exe
+	echo "- OK:  $@ and $@17  call  $@17raw.exe"
+
+run_cvrace_pred: test_cvrace_pred
+	./test_cvrace_pred17raw.exe
+
 test_cvprodcons: stop_token.hpp jthread.hpp condition_variable_any2.hpp test_cvprodcons.cpp test.hpp Makefile
 	$(CXX17) $(CXXFLAGS17) $(INCLUDES) test_cvprodcons.cpp $(LDFLAGS17) -o $@17raw.exe
 	echo PATH=\"$(PATH17)/bin:$$PATH\" ./$@17raw.exe '$$*' > $@17.exe
@@ -112,4 +121,4 @@ jthread.clang: jthread.hpp jthread.cpp stop_token.hpp iwait.hpp test.hpp Makefil
 	echo PATH=\"$(PATH17)/bin:$$PATH\" ./$@clangraw.exe '$$*' > $@.exe
 	echo "- OK:  $@ and $@17  call  $@clangraw.exe"
 
-run_tests: run_cvrace_stop run_cvcb run_cvrace run_cvprodcons run_cv run_jthread2 run_jthread1 run_stokencb run_stoken
+run_tests: run_cvrace_stop run_cvrace_pred run_cvcb run_cvrace run_cvprodcons run_cv run_jthread2 run_jthread1 run_stokencb run_stoken

--- a/source/test_cvrace_pred.cpp
+++ b/source/test_cvrace_pred.cpp
@@ -1,0 +1,43 @@
+#include "condition_variable_any2.hpp"
+#include <mutex>
+#include <thread>
+#include <chrono>
+#include <iostream>
+
+using namespace std::literals::chrono_literals;
+
+std::condition_variable_any2 cv;
+std::mutex mut;
+int sharedStateA = 0;
+int sharedStateB = 0;
+
+void threadA()
+{
+  std::this_thread::sleep_for(100ms);
+  std::unique_lock lock{mut};
+  sharedStateA = 1;
+  cv.notify_all();
+  std::this_thread::sleep_for(100ms);
+  sharedStateB = 1;
+}
+
+void threadB()
+{
+  std::unique_lock lock{mut};
+  cv.wait(lock, [&] {
+    // Since pred() should only be called while holding lock on 'mut'
+    // we should be able to assume invariants protected by the lock.
+    if (sharedStateA != sharedStateB) {
+      std::cout << "ERROR: Invariants maintained by lock not preserved." << std::endl;
+      std::abort();
+    }
+    return sharedStateA == 1;
+  });
+}
+
+int main() {
+  std::thread a{&threadA};
+  threadB();
+  a.join();
+  return 0;
+}


### PR DESCRIPTION
These functions were not reacquiring the user-provided mutex before calling the predicate.