### PR TITLE
Tweak stop_callback deduction guide to unwrap reference_wrapper types

### DIFF
--- a/source/stop_token.hpp
+++ b/source/stop_token.hpp
@@ -558,6 +558,6 @@ class [[nodiscard]] stop_callback : private __stop_callback_base {
 };
 
 template<typename _Callback>
-  stop_callback(stop_token, _Callback) -> stop_callback<_Callback>;
+  stop_callback(stop_token, _Callback) -> stop_callback<std::unwrap_reference_t<_Callback>>;
 
 } // namespace std

--- a/source/test_stoken.cpp
+++ b/source/test_stoken.cpp
@@ -26,7 +26,7 @@ void testStopTokenBasicAPI()
                cb1called = true;
              };
   {
-  std::stop_callback scb1{stok, cb1};
+  std::stop_callback scb1{stok, cb1}; // copies cb1
   assert(ssrc.stop_possible());
   assert(!ssrc.stop_requested());
   assert(stok.stop_possible());
@@ -40,12 +40,12 @@ void testStopTokenBasicAPI()
                assert(stok.stop_requested());
                cb2called = true;
              };
-  //ERROR: std::stop_callback scb2{stok, cb2};
-  //ERROR: ???std::stop_callback<std::remove_cvref_t<decltype(cb2)>> scb2{stok, cb2};
-  //ERROR: std::stop_callback<std::decay_t<decltype(cb2)>> scb2{stok, cb2};
+  //OK: std::stop_callback scb2{stok, cb2};
+  //OK: std::stop_callback<std::decay_t<decltype(cb2)>> scb2{stok, cb2};
   //OK: std::stop_callback<decltype(cb2)&> scb2{stok, cb2};
   //OK:
-  std::stop_callback<decltype(cb2)> scb2{stok, std::move(cb2)};
+  std::stop_callback<decltype(cb2)> scb2a{stok, cb2}; // copies cb2
+  std::stop_callback<decltype(cb2)> scb2b{stok, std::move(cb2)};
   assert(ssrc.stop_possible());
   assert(!ssrc.stop_requested());
   assert(stok.stop_possible());

--- a/source/test_stokencb.cpp
+++ b/source/test_stokencb.cpp
@@ -215,9 +215,9 @@ TEST(CallbackDeregisteredFromWithinCallbackDoesNotDeadlock)
   std::stop_source src;
   std::optional<std::stop_callback<std::function<void()>>> cb;
 
-  cb.emplace(src.get_token(), std::function<void()>{ [&] {
+  cb.emplace(src.get_token(), [&] {
     cb.reset();
-  }});
+  });
 
   src.request_stop();
 

--- a/source/test_stokenrace.cpp
+++ b/source/test_stokenrace.cpp
@@ -89,13 +89,12 @@ void testCallbackUnregister()
   bool cb1called{false};
   std::optional<std::stop_callback<std::function<void()>>> cb;
   cb.emplace(stok,
-             std::function<void()>{ [&] {
-                                      cb1called = true;
-                                      // remove this lambda in optional while being called
-                                      cb.reset();
-                                      //std::this_thread::sleep_for(5s);
-                                    }
-                                  });
+             [&] {
+                cb1called = true;
+                // remove this lambda in optional while being called
+                cb.reset();
+                //std::this_thread::sleep_for(5s);
+              });
   assert(ssrc.stop_possible());
   assert(!ssrc.stop_requested());
   assert(stok.stop_possible());
@@ -122,10 +121,9 @@ struct RegUnregCB {
 
   void reg(std::stop_token& stok) {
     cb.emplace(stok,
-               std::function<void()>{ [&] {
-                                        called = true;
-                                      }
-                                    });
+               [&] {
+                 called = true;
+               });
   }
   void unreg() {
     cb.reset();

--- a/tex/jthread.tex
+++ b/tex/jthread.tex
@@ -134,7 +134,7 @@ namespace std {
   };
 
   template <typename Callback>
-  stop_callback(stop_token, Callback) -> stop_callback<Callback>;
+  stop_callback(stop_token, Callback) -> stop_callback<unwrap_reference_t<Callback>>;
 }
 \end{codeblock}
 

--- a/tex/jthread.tex
+++ b/tex/jthread.tex
@@ -87,7 +87,7 @@ or \tcode{stop_source} that returns \tcode{true}.
 namespace std {
   // \ref{stop_callback} class \tcode{stop_callback}
   template <Invocable Callback>
-    requires MoveConstructible<Callback>
+    requires Destructible<Callback>
   class stop_callback;
   // \ref{stop_source} class \tcode{stop_source}
   class stop_source;
@@ -109,14 +109,18 @@ namespace std {
 \begin{codeblock}
 namespace std {
   template <Invocable Callback>
-    requires MoveConstructible<Callback>
+    requires Destructible<Callback>
   class stop_callback {
   public:
     // \ref{stop_callback.constr} create, destroy:
-    explicit stop_callback(const stop_token& st, Callback&& cb)
-        noexcept(std::is_nothrow_move_constructible_v<Callback>);
-    explicit stop_callback(stop_token&& st, Callback&& cb)
-        noexcept(std::is_nothrow_move_constructible_v<Callback>);
+    template <typename C>
+        requires Constructible<Callback, C>
+    explicit stop_callback(const stop_token& st, C&& cb)
+        noexcept(std::is_nothrow_constructible_v<Callback, C>);
+    template <typename C>
+        requires Constructible<Callback, C>
+    explicit stop_callback(stop_token&& st, C&& cb)
+        noexcept(std::is_nothrow_constructible_v<Callback, C>);
     ~stop_callback();
 
     stop_callback(const stop_callback&) = delete;
@@ -130,10 +134,7 @@ namespace std {
   };
 
   template <typename Callback>
-  stop_callback(const stop_token&, Callback&&) -> stop_callback<Callback>;
-
-  template <typename Callback>
-  stop_callback(stop_token&&, Callback&&) -> stop_callback<Callback>;
+  stop_callback(stop_token, Callback) -> stop_callback<Callback>;
 }
 \end{codeblock}
 
@@ -142,13 +143,17 @@ namespace std {
 
 \indexlibrary{\idxcode{stop_callback}!constructor}%
 \begin{itemdecl}
-explicit stop_callback(const stop_token& st, Callback&& cb)
-  noexcept(std::is_nothrow_move_constructible_v<Callback>);
-explicit stop_callback(stop_token&& st, Callback&& cb)
-  noexcept(std::is_nothrow_move_constructible_v<Callback>);
+template <typename C>
+  requires Constructible<Callback, C>
+explicit stop_callback(const stop_token& st, C&& cb)
+  noexcept(std::is_nothrow_constructible_v<Callback, C>);
+template <typename C>
+  requires Constructible<Callback, C>
+explicit stop_callback(stop_token&& st, C&& cb)
+  noexcept(std::is_nothrow_constructible_v<Callback, C>);
 \end{itemdecl}
 \begin{itemdescr}
-  \pnum\effects Initialises \tcode{callback} with \tcode{static_cast<Callback\&\&>(cb)}.
+  \pnum\effects Initialises \tcode{callback} with \tcode{static_cast<C\&\&>(cb)}.
                 If \tcode{st.stop_requested()} is \tcode{true} then immediately invokes
                 \tcode{static_cast<Callback\&\&>(callback)}
                 with zero arguments in the current thread before the constructor returns.

--- a/tex/jthreadP660.tex
+++ b/tex/jthreadP660.tex
@@ -193,7 +193,7 @@ std::stop_token stok{ssrc.get_token()};
 // register callback
 bool cb1called{false};
 auto cb1 = [&]{ cb1called = true; };
-std::stop_callback scb1{stok, cb1};  // stop_callback holds reference to cb1
+std::stop_callback scb1{stok, cb1};  // stop_callback copies cb1
 assert(!cb1called);
 
 // request stop
@@ -361,11 +361,15 @@ The terminology was carefully selected with the following reasons
         that is shared by both \tcode{stop_source}s and \tcode{stop_token}s.
 \end{itemize}
 
-The deduction guide for \tcode{stop_callback}s enables
-constructing a \tcode{stop_callback} with an lvalue callable:
+The deduction guide for \tcode{stop_callback}s deduces the callback argument such
+that the constructor performs a decay-copy of the callback argument.
+
+If you want to instead capture the callback by reference you can use \tcode{std::ref()} to
+pass a \tcode{std::reference_wrapper<T>} object.
 \begin{codeblock}
 auto lambda = []{};
-std::stop_callback cb{ token, lambda };  // captures by reference
+std::stop_callback cb1{ token, lambda };  // copies the lambda
+std::stop_callback cb2{ token, std::ref(lambda) }; // captures lambda by reference
 \end{codeblock}
 
 Adding a new callback is \tcode{noexcept} (unless moving the passed function throws).


### PR DESCRIPTION
This is an incremental improvement on top of https://github.com/josuttis/jthread/pull/23 that allows the stop_callback deduction guide to deduce the callback template parameter to the unwrapped type of a reference wrapper object.

ie. instead of 
```
auto lambda = []{};
std::stop_callback cb{token, std::ref(lambda)};
```
deducing the `Callback` template parameter to `std::reference_wrapper<decltype(lambda)>`
it would deduce the template parameter to be `decltype(lambda)&`.

Thanks to @jwakely for the suggestion.