### PR TITLE
Editorial changes

### DIFF
--- a/tex/jthread.tex
+++ b/tex/jthread.tex
@@ -83,7 +83,7 @@ associated with the \tcode{stop_token} used to construct the \tcode{stop_callbac
 Calls to \tcode{request_stop()}, \tcode{stop_requested()},
 and \tcode{stop_possible()}
 do not introduce data races. 
-A call to \tcode{request_stop()} that return \tcode{true}
+A call to \tcode{request_stop()} that returns \tcode{true}
 synchronizes with a call to \tcode{stop_requested()} on an associated \tcode{stop_token}
 or \tcode{stop_source} that returns \tcode{true}.
 %NEW:
@@ -1484,7 +1484,7 @@ template<class Lock, class Rep, class Period, class Predicate>
 \begin{itemdescr}
  \pnum \effects Equivalent to:
 \begin{codeblock}
-return wait_until(lock, chrono::steady_clock::now() + rel_time, std::move(pred), std::move(stoken));
+return wait_until(lock, chrono::steady_clock::now() + rel_time, move(pred), move(stoken));
 \end{codeblock}
 \end{itemdescr}
 

--- a/tex/jthreadP660.tex
+++ b/tex/jthreadP660.tex
@@ -22,7 +22,7 @@ Prev. Version:	& \url{www.wg21.link/P0660R9}, \url{www.wg21.link/P1287R0} \\
 
 \subsubsection*{New in R10}
 \begin{itemize}
- \item \tcode{request_stop} returns whether the staop state was changed.
+ \item \tcode{request_stop} returns whether the stop state was changed.
  \item \tcode{stop_callback} has type member \tcode{callback_type}.
  \item \tcode{stop_callback} constructor supports copying/conversion of callback.
  \item \tcode{stop_callback} deduction guide now deduces to decayed type


### PR DESCRIPTION
Remove std:: prefix from wait_until() description.