### PR TITLE
Make stop_token terminology for associated/owned things consistent.

### DIFF
--- a/tex/jthread.tex
+++ b/tex/jthread.tex
@@ -60,7 +60,10 @@ Such a request is called a \defn{stop request}.
 
 \pnum
 \tcode{stop_source}, \tcode{stop_token}, and \tcode{stop_callback}
-implement semantics of shared ownership of an associated shared stop state.
+implement semantics of shared ownership of a \defn(stop state).
+Any \tcode{stop_source}, \tcode{stop_token} or \tcode{stop_callback}
+that shares ownership of the same stop state is an \defn(associated)
+\tcode{stop_source}, \tcode{stop_token} or \tcode{stop_callback}, respectively.
 The last remaining owner of the stop state automatically 
 releases the resources associated with the stop state.
 
@@ -71,25 +74,22 @@ A \tcode{stop_token} can be passed to an operation which can either
  \item register a callback using the \tcode{stop_callback} class template which
         will be called in the event that a stop request is made.
 \end{itemize}
-A request
-to stop can be made via any associated
-\tcode{stop_source} object and this request will be visible to all associated
-\tcode{stop_token} objects.
-Once a stop request has been made it cannot be
-withdrawn (a subsequent stop request has no effect).
+A stop request made via a \tcode{stop_source} will be visible to all
+associated \tcode{stop_token} and \tcode{stop_source} objects.
+Once a stop request has been made it cannot be withdrawn
+(a subsequent stop request has no effect).
 
 \pnum
 Callbacks registered via a \tcode{stop_callback} object are called when
-a stop request is first made by any of the \tcode{stop_source} objects
-associated with the \tcode{stop_token} used to construct the \tcode{stop_callback}.
+a stop request is first made by any associated \tcode{stop_source} object.
 
 \pnum
 Calls to the functions \tcode{request_stop}, \tcode{stop_requested},
 and \tcode{stop_possible}
 do not introduce data races. 
-A call to \tcode{request_stop()} that returns \tcode{true}
-synchronizes with a call to \tcode{stop_requested()} on an associated \tcode{stop_token}
-or \tcode{stop_source} that returns \tcode{true}.
+A call to \tcode{request_stop} that returns \tcode{true}
+synchronizes with a call to \tcode{stop_requested} on an associated \tcode{stop_token}
+or \tcode{stop_source} object that returns \tcode{true}.
 %NEW:
 Registration of a callback synchronizes with the invocation of that callback.
 
@@ -129,11 +129,11 @@ namespace std {
 \indexlibrary{\idxcode{stop_token}}%
 The class \tcode{stop_token} provides an interface for querying whether
 a stop request has been made (\tcode{stop_requested()}) or can ever be made
-(\tcode{stop_possible()}) from an associated \tcode{stop_source} object (\ref{stopsource}).
+(\tcode{stop_possible()}) using an associated \tcode{stop_source} object (\ref{stopsource}).
 A \tcode{stop_token} can also be passed to a
 \tcode{stop_callback} (\ref{stopcallback}) constructor
 to register a callback to be called when a stop request has been made from
-an associated \tcode{top_source}. 
+an associated \tcode{stop_source}. 
 
 \begin{codeblock}
 namespace std {
@@ -173,8 +173,8 @@ stop_token() noexcept;
 \begin{itemdescr}
   \pnum\postconditions \tcode{stop_possible()} is \tcode{false} and 
                        \tcode{stop_requested()} is \tcode{false}.
-        \begin{note} Because the created \tcode{stop_token} object that can never receive a stop request.
-                     no resources are associated for the state.  \end{note}
+        \begin{note} As the created \tcode{stop_token} object that can never receive a stop request,
+                     no resources are allocated for a stop state.  \end{note}
 
 \end{itemdescr}
 
@@ -187,7 +187,7 @@ stop_token(const stop_token& rhs) noexcept;
 \begin{itemdescr}
   \pnum\postconditions \tcode{*this == rhs} is \tcode{true}.
         \begin{note} \tcode{*this} and \tcode{rhs} share the ownership of the
-                        same associated stop state, if any.  \end{note}
+                        same stop state, if any.  \end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_token}!constructor}%
@@ -210,7 +210,7 @@ stop_token(stop_token&& rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
- \pnum\effects Releases the ownership of the associated shared stop state, if any.
+ \pnum\effects Releases ownership of the stop state, if any.
 \end{itemdescr}
 
 %*******************
@@ -264,7 +264,7 @@ void swap(stop_token& rhs) noexcept;
 [[nodiscard]] bool stop_requested() const noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-  \pnum\returns \tcode{true} if there is an associated shared stop state that has received a stop request;
+  \pnum\returns \tcode{true} if \tcode{*this} has ownership of a stop state that has received a stop request;
                 otherwise, \tcode{false}.
                 
                 ??? The determination of the return value is performed atomically. ???
@@ -280,31 +280,12 @@ void swap(stop_token& rhs) noexcept;
 [[nodiscard]] bool stop_possible() const noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-  ???:
-
   \pnum\returns \tcode{false} if:
   \begin{itemize}
-   \item there is no associated shared stop state, or
-   \item a stop request was not made and 
-         an implementation detects that the associated shared stop state can never receive a stop request;
+   \item \tcode{*this} does not have ownership of a stop state, or
+   \item \tcode{stop_requested()} is \tcode{false} and there are no associated \tcode{stop_source} objects;
   \end{itemize}
         otherwise, \tcode{true}.
-        \begin{note} Implementations are permitted to return \tcode{false} when no request to stop
-                     has been made and no more \tcode{stop_source}
-                     objects exists that share the ownership of the associated shared stop state.
-                \end{note}
-
-  ???:
-  \pnum\returns \tcode{true} if:
-  \begin{itemize}
-   \item a stop request was made on the associated shared stop state, or
-   \item no stop request was made on the associated shared stop state
-         and an implementations didn't detect that 
-         the associated shared stop state can never receive a stop request
-         (e.g., because no more \tcode{stop_source} objects share this state);
-  \end{itemize}
-        otherwise, \tcode{false}.
-
 \end{itemdescr}
 
 
@@ -318,10 +299,10 @@ void swap(stop_token& rhs) noexcept;
 [[nodiscard]] bool operator==(const stop_token& lhs, const stop_token& rhs) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-  \pnum\returns \tcode{true} if \tcode{lhs} and \tcode{rhs} own the same
-                associated stop state
+  \pnum\returns \tcode{true} if \tcode{lhs} and \tcode{rhs} share ownership
+                of the same stop state
                 (copied or moved from the same initial \tcode{stop_source} object),
-                or if both \tcode{lhs} and \tcode{rhs} have no associated stop state;
+                or if both \tcode{lhs} and \tcode{rhs} do not have ownership of a stop state;
                 otherwise \tcode{false}.
 \end{itemdescr}
 
@@ -358,11 +339,11 @@ friend void swap(stop_token& x, stop_token& y) noexcept;
 
 \pnum
 \indexlibrary{\idxcode{stop_source}}%
-The class \tcode{stop_source} implements the semantics of signaling a stop request
-to \tcode{stop_token} objects (\ref{stoptoken}) sharing the associated shared stop state.
-All \tcode{stop_source} objects sharing the associated shared stop state can make a stop request.
-Once a stop request has been made it cannot be withdrawn.
-A subsequent stop request has no effect.
+The class \tcode{stop_source} implements the semantics of making a stop request.
+A stop request made on a \tcode{stop_source} object is visible to all
+associated \tcode{stop_source} and \tcode{stop_token} (\ref{stoptoken}) objects.
+Once a stop request has been made it cannot be withdrawn
+(a subsequent stop request has no effect).
 
 \indexlibrary{\idxcode{nostopstate_t}}%
 \indexlibrary{\idxcode{nostopstate}}%
@@ -435,9 +416,10 @@ namespace std {
 stop_source();
 \end{itemdecl}
 \begin{itemdescr}
+  \pnum\effects Initialises \tcode{*this} to have ownership of a new stop state.
   \pnum\postconditions \tcode{stop_possible()} \tcode{\&\&} \tcode{!stop_requested()} is \tcode{true}.
 
-  \pnum\throws \tcode{bad_alloc} if memory could not be allocated for the shared stop state.
+  \pnum\throws \tcode{bad_alloc} if memory could not be allocated for the stop state.
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_source}!constructor}%
@@ -447,7 +429,7 @@ explicit stop_source(nostopstate_t) noexcept;
 \begin{itemdescr}
   \pnum\postconditions \tcode{stop_possible()} is \tcode{false} and
                        \tcode{stop_requested()} is \tcode{false}.
-                \begin{note} No resources are associated for the state.  \end{note}
+                \begin{note} No resources are allocated for the state.  \end{note}
 \end{itemdescr}
 
 %*** special members:
@@ -465,6 +447,8 @@ stop_source(const stop_source& rhs) noexcept;
   %       could return 'false' if another thread concurrently called request_stop().
   %       Is this a problem putting it in in a post-condition?
   \pnum\postconditions \tcode{*this == rhs} is \tcode{true}.
+    \begin{note} \tcode{*this} and \tcode{rhs} share the ownership of the
+                 same stop state, if any.  \end{note}
 \end{itemdescr}
 
 \indexlibrary{\idxcode{stop_source}!constructor}%
@@ -487,7 +471,7 @@ stop_source(stop_source&& rhs) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
- \pnum\effects Releases the ownership of the associated shared stop state, if any.
+ \pnum\effects Releases ownership of the stop state, if any.
 \end{itemdescr}
 
 %*******************
@@ -541,8 +525,7 @@ void swap(stop_source& rhs) noexcept;
 \end{itemdecl}
 \begin{itemdescr}
   \pnum\returns \tcode{stoken()} if \tcode{stop_possible()} is \tcode{false};
-                otherwise a \tcode{stop_token} object
-                that shares the ownership of the stop state with \tcode{sc}.
+                otherwise an associated \tcode{stop_token} object.
 \end{itemdescr}
 
 
@@ -551,7 +534,7 @@ void swap(stop_source& rhs) noexcept;
 [[nodiscard]] bool stop_possible() const noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-  \pnum\returns \tcode{true} if \tcode{*this} has an associated shared stop state;
+  \pnum\returns \tcode{true} if \tcode{*this} has ownership of a stop state;
                 otherwise, \tcode{false}.
                 % NOT NECESSARY:
                 %The determination of the return values is performed atomically.
@@ -566,7 +549,7 @@ void swap(stop_source& rhs) noexcept;
 [[nodiscard]] bool stop_requested() const noexcept;
 \end{itemdecl}
 \begin{itemdescr}
-  \pnum\returns \tcode{true} if there is an associated shared stop state that has received a stop request;
+  \pnum\returns \tcode{true} if \tcode{*this} has ownership of a stop state that has received a stop request;
                 otherwise, \tcode{false}.
                 
                 ??? The determination of the return value is performed atomically. ???
@@ -584,13 +567,13 @@ bool request_stop() noexcept;
   %Presumably a lot of short-lived tasks don't care about stopping/interruption, but might be used in a context in which an
   %stop/interrupt token is expected. With the change, you could just pass a default-constructed one.
 
-  \pnum\effects If there is no associated shared state, returns \tcode{false}. 
-                Otherwise, atomically determines whether the associated shared stop state has received a stop request,
+  \pnum\effects If \tcode{*this} does not have ownership of a stop state, returns \tcode{false}. 
+                Otherwise, atomically determines whether the owned stop state has received a stop request,
                 and if not, makes a stop request.
                 The determination and making of the stop request are an
                 atomic read-modify-write operation \iref{intro.races}.
-                If the request was made, the callbacks registered with the associated shared stop state
-                are synchronously called.
+                If the request was made, the callbacks registered by associated \tcode{stop_callback}
+                objects are synchronously called.
                 If an invocation of a callback exits via an exception 
                 then \tcode{terminate()} is called.
                 \begin{note} A stop request includes notifying all condition variables
@@ -600,7 +583,7 @@ bool request_stop() noexcept;
 
   \pnum\postconditions \tcode{stop_possible()} is \tcode{false} or \tcode{stop_requested()} is \tcode{true}.
 
-  \pnum\returns \tcode{true} if the shared stop state changed due to this call.
+  \pnum\returns \tcode{true} if this call made a stop request.
 \end{itemdescr}
 
 
@@ -616,7 +599,7 @@ bool request_stop() noexcept;
 \begin{itemdescr}
   \pnum\returns \tcode{true} if \tcode{!lhs.stop_possible() \&\& !rhs.stop_possible()},
                 \tcode{true} if \tcode{lhs} and \tcode{rhs} share ownership
-                of the associated stop state
+                of the same stop state
                 (copied or moved from the same initial \tcode{stop_source} object),
                 otherwise \tcode{false}.
 \end{itemdescr}
@@ -716,11 +699,12 @@ explicit stop_callback(stop_token&& st, C&& cb)
                 \tcode{static_cast<Callback\&\&>(callback)()}
                 is evaluated
                 in the current thread before the constructor returns.
-                Otherwise, the callback is registered with the shared stop state of \tcode{st}
-                such that \tcode{static_cast<Callback\&\&>(callback)()} is evaluated
-                by the first call to \tcode{src.request_stop()}
-                on any \tcode{stop_source} instance \tcode{src} that references the associated shared stop
-                state as \tcode{st}.
+                Otherwise, if \tcode{st} has ownership of a stop state,
+                acquires shared ownership of that stop state and registers
+                the callback with that stop state such that \tcode{static_cast<Callback\&\&>(callback)()}
+                is evaluated by the first call to \tcode{request_stop()} on an associated
+                \tcode{stop_source}.
+
                 If invoking the callback exits via an exception,
                 then \tcode{terminate()} is called.
 
@@ -732,7 +716,7 @@ explicit stop_callback(stop_token&& st, C&& cb)
 ~stop_callback();
 \end{itemdecl}
 \begin{itemdescr}
-  \pnum\effects Unregisters the callback from the associated shared stop state.
+  \pnum\effects Unregisters the callback from the owned stop state, if any, 
                 The destructor does not block waiting for the execution of another callback registered
                 with the associated shared stop state to finish.
                 If \tcode{callback} is concurrently executing on another thread, then the return
@@ -742,6 +726,7 @@ explicit stop_callback(stop_token&& st, C&& cb)
                 If \tcode{callback} is executing on the current thread, then
                 the destructor does not block (\iref{defns.block}) waiting for the return from
                 the invocation of \tcode{callback}.
+                Releases ownership of the stop state, if any.
 
                 %\tcode{callback} is destroyed.
                 %% TODO: FIX WORDING HERE:
@@ -1752,7 +1737,7 @@ otherwise, the provided forward progress guarantee is implementation-defined.
 In [cfenv.syn]/2:
 }
 
-The floating-point environment has thread storage duration (6.6.5.2). The initial state for a thread’s
+The floating-point environment has thread storage duration (6.6.5.2). The initial state for a threadï¿½s
 floating-point environment is the state of the floating-point environment of the thread that constructs the
 corresponding \tcode{}thread object (32.3.2) 
 {\color{insertcolor}


### PR DESCRIPTION
- Define term 'stop state'.
- Use phrase "having ownership of a stop state" to describe relationship between token/source/callback and the stop state.
- Use phrase "associated token/source/callback" to refer to objects that
  share ownership of the same stop state.
- Use 'acquiring ownership' and 'releasing ownership' of stop states.
- stop_callbck constructor make registration conditional on stop token
  having ownership of a stop state.
- stop_callback destructor adds wording to release ownership.