### PR TITLE
Stop and join a joinable jthread before being assigned.

### DIFF
--- a/source/jthread.hpp
+++ b/source/jthread.hpp
@@ -43,7 +43,7 @@ class jthread
     jthread(const jthread&) = delete;
     jthread(jthread&&) noexcept = default;
     jthread& operator=(const jthread&) = delete;
-    jthread& operator=(jthread&&) noexcept = default;
+    jthread& operator=(jthread&&) noexcept;
 
     // members:
     void swap(jthread&) noexcept;
@@ -116,6 +116,18 @@ inline jthread::jthread(Callable&& cb, Args&&... args)
                ::std::forward<Args>(args)...  // pass arguments for callable
            }
 {
+}
+
+// move assignment operator:
+inline jthread& jthread::operator=(jthread&& t) noexcept {
+  if (joinable()) {   // if not joined/detached, signal stop and wait for end:
+    request_stop();
+    join();
+  }
+
+  _thread = std::move(t._thread);
+  _stopSource = std::move(t._stopSource);
+  return *this;
 }
 
 // destructor:

--- a/source/test_jthread1.cpp
+++ b/source/test_jthread1.cpp
@@ -209,6 +209,34 @@ void testDetach()
 
 //------------------------------------------------------
 
+void testAssign()
+{
+  // test jthread operator=()
+  std::cout << "\n*** start testAssign()" << std::endl;
+
+  std::stop_token stoken;
+  {
+    std::jthread t1([](std::stop_token stoken) {
+                      // wait until interrupt is signaled (due to calling request_stop() for the token):
+                      for (int i=0; !stoken.stop_requested(); ++i) {
+                         std::this_thread::sleep_for(100ms);
+                         std::cout.put('.').flush();
+                      }
+                      std::cout << "END t1" << std::endl;
+                 });
+    stoken = t1.get_stop_token();
+    assert(!stoken.stop_requested());
+    assert(t1.joinable());
+    // t1 is stopped and joined before being assigned:
+    t1 = std::jthread();
+    assert(stoken.stop_requested());
+    assert(!t1.joinable());
+  }
+  std::cout << "\n*** OK" << std::endl;
+}
+
+//------------------------------------------------------
+
 void testStdThread()
 {
   // test the extended std::thread API
@@ -436,6 +464,8 @@ int main()
   testJoin();
   std::cout << "\n\n**************************\n";
   testDetach();
+  std::cout << "\n\n**************************\n";
+  testAssign();
   std::cout << "\n\n**************************\n";
   testStdThread();
   std::cout << "\n\n**************************\n";


### PR DESCRIPTION
A joinable jthread should stop and join the associated thread before being assigned.

https://eel.is/c++draft/thread.jthread.class#thread.jthread.cons-13