### PR TITLE
remove redundant namespace qualification

### DIFF
--- a/source/stop_token.hpp
+++ b/source/stop_token.hpp
@@ -409,7 +409,7 @@ class stop_source {
  public:
   stop_source() : __state_(new __stop_state()) {}
 
-  explicit stop_source(std::nostopstate_t) noexcept : __state_(nullptr) {}
+  explicit stop_source(nostopstate_t) noexcept : __state_(nullptr) {}
 
   ~stop_source() {
     if (__state_ != nullptr) {


### PR DESCRIPTION
First, thanks for implementing this and making it open-source.

I want to adopt jthread in my codebase, but I want to put jthread in a namespace other than std to make it explicit that it's not yet in the standard library + for avoiding future ODR errors when upgrading to a newer compiler version that supports jthread. This change makes it possible to put jthread in another namespace just by changing 'namespace std' to 'namespace whatever' in jthread.hpp and stop_token.hpp. I don't know if this could be helpful for other people, but the std:: qualification of nostopstate_t (which I removed) seems redundant