### PR TITLE
Remove const qualifier of `std::stop_source::request_stop()`

### DIFF
--- a/source/stop_token.hpp
+++ b/source/stop_token.hpp
@@ -449,7 +449,7 @@ class stop_source {
     return __state_ != nullptr;
   }
 
-  bool request_stop() const noexcept {
+  bool request_stop() noexcept {
     if (__state_ != nullptr) {
       return __state_->__request_stop();
     }


### PR DESCRIPTION
Remove const qualifier of `std::stop_source::request_stop()` in accordance with what was standardized in C++20.
This fixes #40 