### PR TITLE
Fix __stop_state double delete. (fix #42) 

### DIFF
--- a/source/stop_token.hpp
+++ b/source/stop_token.hpp
@@ -53,7 +53,7 @@ struct __stop_state {
   void __remove_token_reference() noexcept {
     auto __oldState =
         __state_.fetch_sub(__token_ref_increment, std::memory_order_acq_rel);
-    if (__oldState < (__token_ref_increment + __source_ref_increment)) {
+    if (__oldState < (__token_ref_increment + __token_ref_increment)) {
       delete this;
     }
   }


### PR DESCRIPTION
Repro steps: 

- create a stop_source
- get two stop tokens
- destroy the source
- destroy one of the stop_token (the internal state is deleted)
- destroy the second stop_token (double delete of the internal state) 